### PR TITLE
Prefix is now HC1:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.digg.dgc</groupId>
   <artifactId>dgc-create-validate</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1-SNAPSHOT</version>
 
   <name>DIGG :: Digital Green Certificate :: Issuance and Validation</name>
   <description>Issuance and validation of Digital Green Certificate</description>

--- a/src/main/java/se/digg/dgc/encoding/DGCConstants.java
+++ b/src/main/java/se/digg/dgc/encoding/DGCConstants.java
@@ -18,7 +18,7 @@ public class DGCConstants {
    * Header string that is prefixed to Base45 encoded health care certificates containing version 1 of the Digital Green
    * Certificate payloads.
    */
-  public static final String DGC_V1_HEADER = "HC1";
+  public static final String DGC_V1_HEADER = "HC1:";
   
   // Hidden constructor
   private DGCConstants() {


### PR DESCRIPTION
Version 1.0.4 of the hcert spec specifies that the prefix should be "HC1:".
