### PR TITLE
Dependencies for spring5 and credentials-support removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,12 +131,6 @@
       <version>${bouncy-castle.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>se.swedenconnect.security</groupId>
-      <artifactId>credentials-support</artifactId>
-      <version>${credentials-support.version}</version>
-    </dependency>
-    
     <!-- For testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/se/digg/dgc/helper/PkiCredentialHelper.java
+++ b/src/main/java/se/digg/dgc/helper/PkiCredentialHelper.java
@@ -1,0 +1,69 @@
+package se.digg.dgc.helper;
+
+import com.nimbusds.jose.util.X509CertUtils;
+import org.bouncycastle.asn1.x500.style.RFC4519Style;
+import org.bouncycastle.jce.PrincipalUtil;
+import se.digg.dgc.signatures.impl.PkiCredential;
+
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+
+/**
+ * A simple helper class for loading X509Certificates
+ *
+ * @author Johannes Marchart, johannes.marchart@itsv.at
+ */
+public class PkiCredentialHelper {
+
+    /**
+     * @param jksFileName the path to the JKS keystore
+     * @param jksPassword the password for the JKS
+     * @param countryCode     the two letter ISO-3166 country code
+     * @throws KeyStoreException
+     */
+    public static PkiCredential getFromJKS(String jksFileName, String jksPassword, String countryCode) throws KeyStoreException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+            keyStore.load(getResourceInputStream(jksFileName), jksPassword.toCharArray());
+            Enumeration<String> aliases = keyStore.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                Certificate certificate = keyStore.getCertificate(alias);
+                if (certificate instanceof X509Certificate) {
+                    String c = (String) PrincipalUtil.getSubjectX509Principal((X509Certificate) certificate).getValues(RFC4519Style.c).get(0);
+                    if (c.equalsIgnoreCase(countryCode)) {
+                        PkiCredential pkiCredential = new PkiCredential();
+                        pkiCredential.setCertificate((X509Certificate) certificate);
+                        pkiCredential.setPrivateKey((PrivateKey) keyStore.getKey(alias, jksPassword.toCharArray()));
+                        pkiCredential.setPublicKey(certificate.getPublicKey());
+                        return pkiCredential;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new KeyStoreException(e.getMessage(), e);
+        }
+        throw new KeyStoreException("No such certificate found in " + jksFileName + " with country " + countryCode);
+    }
+
+    /**
+     * @param pemFilenName the path to the PEM encoded certificate
+     * @return
+     * @throws Exception
+     */
+    public static X509Certificate getFromPEM(String pemFilenName) throws Exception {
+        String pem = new String(getResourceInputStream(pemFilenName).readAllBytes());
+        return X509CertUtils.parse(pem);
+    }
+
+    public static InputStream getResourceInputStream(String path) {
+        return PkiCredentialHelper.class.getClassLoader().getResourceAsStream(path);
+    }
+
+
+}

--- a/src/main/java/se/digg/dgc/signatures/impl/DefaultDGCSigner.java
+++ b/src/main/java/se/digg/dgc/signatures/impl/DefaultDGCSigner.java
@@ -1,24 +1,12 @@
 /*
  * MIT License
- * 
+ *
  * Copyright 2021 Myndigheten för digital förvaltning (DIGG)
  */
 package se.digg.dgc.signatures.impl;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.SignatureException;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.ECPublicKey;
-import java.security.interfaces.RSAPublicKey;
-import java.time.Instant;
-
+import com.upokecenter.cbor.CBORException;
+import com.upokecenter.cbor.CBORObject;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
@@ -28,21 +16,28 @@ import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x509.Certificate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.upokecenter.cbor.CBORException;
-import com.upokecenter.cbor.CBORObject;
-
 import se.digg.dgc.signatures.DGCSigner;
 import se.digg.dgc.signatures.cose.CoseSign1_Object;
 import se.digg.dgc.signatures.cose.HeaderParameterKey;
 import se.digg.dgc.signatures.cose.SignatureAlgorithm;
 import se.digg.dgc.signatures.cwt.Cwt;
-import se.swedenconnect.security.credential.BasicCredential;
-import se.swedenconnect.security.credential.PkiCredential;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.SignatureException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
 
 /**
  * A bean implementing the {@link DGCSigner} interface.
- * 
+ *
  * @author Martin Lindström (martin@idsec.se)
  * @author Henrik Bengtsson (extern.henrik.bengtsson@digg.se)
  * @author Henric Norlander (extern.henric.norlander@digg.se)
@@ -50,188 +45,168 @@ import se.swedenconnect.security.credential.PkiCredential;
 public class DefaultDGCSigner implements DGCSigner {
 
   /** Logger */
-  private static final Logger log = LoggerFactory.getLogger(DefaultDGCSigner.class);
+    private static final Logger log = LoggerFactory.getLogger(DefaultDGCSigner.class);
 
   /** The credential that we are using for signing. */
-  private final PkiCredential signerCredential;
+    private final PkiCredential signerCredential;
 
   /** The Java Security Provider to use when signing. */
-  private Provider securityProvider;
+    private Provider securityProvider;
 
   /** The issuer country. */
-  private final String country;
+    private final String country;
 
   /** The key identifier that is used. */
-  private final byte[] keyIdentifier;
+    private final byte[] keyIdentifier;
 
   /** The expiration time for the signer's certificate. */
-  private final Instant signerExpiration;
+    private final Instant signerExpiration;
 
   /** The algorithm to use when signing. */
-  private SignatureAlgorithm algorithmIdentifier;
+    private SignatureAlgorithm algorithmIdentifier;
 
-  /**
-   * Constructor.
-   * 
-   * @param signerKey
-   *          the signer key
-   * @param signerCertificate
-   *          the certificate holding the public key corresponding to the signer key
-   * @throws CertificateException
-   *           for certificate decoding errors
-   */
-  public DefaultDGCSigner(final PrivateKey signerKey, final X509Certificate signerCertificate) throws CertificateException {
-    this(new BasicCredential(signerCertificate, signerKey));
-  }
 
-  /**
-   * Constructor.
-   * 
-   * @param signerCredential
-   *          the signer credential
-   * @throws CertificateException
-   *           for certificate decoding errors
-   */
-  public DefaultDGCSigner(final PkiCredential signerCredential) throws CertificateException {
-    this.signerCredential = signerCredential;
-    this.country = getCountry(signerCredential.getCertificate());
-    this.keyIdentifier = calculateKid(signerCredential.getCertificate());
-    this.signerExpiration = Instant.ofEpochMilli(signerCredential.getCertificate().getNotAfter().getTime());
+    /**
+     * Constructor.
+     *
+     * @param signerCredential the signer credential
+     * @throws CertificateException for certificate decoding errors
+     */
+    public DefaultDGCSigner(final PkiCredential signerCredential) throws CertificateException {
+        this.signerCredential = signerCredential;
+        this.country = getCountry(signerCredential.getCertificate());
+        this.keyIdentifier = calculateKid(signerCredential.getCertificate());
+        this.signerExpiration = Instant.ofEpochMilli(signerCredential.getCertificate().getNotAfter().getTime());
 
-    if (ECPublicKey.class.isInstance(this.signerCredential.getPublicKey())) {
-      this.algorithmIdentifier = SignatureAlgorithm.ES256;
+        if (this.signerCredential.getPublicKey() instanceof ECPublicKey) {
+            this.algorithmIdentifier = SignatureAlgorithm.ES256;
+        } else if (this.signerCredential.getPublicKey() instanceof RSAPublicKey) {
+            this.algorithmIdentifier = SignatureAlgorithm.PS256;
+        } else {
+            throw new SecurityException("Unsupported key");
+        }
     }
-    else if (RSAPublicKey.class.isInstance(this.signerCredential.getPublicKey())) {
-      this.algorithmIdentifier = SignatureAlgorithm.PS256;
-    }
-    else {
-      throw new SecurityException("Unsupported key");
-    }
-  }
 
   /** {@inheritDoc} */
-  @Override
-  public byte[] sign(final byte[] dgcPayload, final Instant expiration) throws SignatureException {
+    @Override
+    public byte[] sign(final byte[] dgcPayload, final Instant expiration) throws SignatureException {
 
-    if (expiration.isAfter(this.signerExpiration)) {
-      log.warn("Expiration of DGC goes beyond the signer certificate validity");
+        if (expiration.isAfter(this.signerExpiration)) {
+            log.warn("Expiration of DGC goes beyond the signer certificate validity");
+        }
+
+        try {
+            final Cwt cwt = Cwt.builder()
+                    .issuer(this.country)
+                    .issuedAt(Instant.now())
+                    .expiration(expiration)
+                    .dgcV1(dgcPayload)
+                    .build();
+
+            final CoseSign1_Object coseObject = CoseSign1_Object.builder()
+                    .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), this.algorithmIdentifier.getCborObject())
+                    .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(this.keyIdentifier))
+                    .content(cwt.encode())
+                    .build();
+
+            coseObject.sign(this.signerCredential.getPrivateKey(), this.securityProvider);
+
+            return coseObject.encode();
+        } catch (CBORException e) {
+            throw new SignatureException("CBOR error - " + e.getMessage(), e);
+        }
     }
-
-    try {
-      final Cwt cwt = Cwt.builder()
-        .issuer(this.country)
-        .issuedAt(Instant.now())
-        .expiration(expiration)
-        .dgcV1(dgcPayload)
-        .build();
-
-      final CoseSign1_Object coseObject = CoseSign1_Object.builder()
-        .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), this.algorithmIdentifier.getCborObject())
-        .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(this.keyIdentifier))
-        .content(cwt.encode())
-        .build();
-
-      coseObject.sign(this.signerCredential.getPrivateKey(), this.securityProvider);
-
-      return coseObject.encode();
-    }
-    catch (CBORException e) {
-      throw new SignatureException("CBOR error - " + e.getMessage(), e);
-    }
-  }
 
   /** {@inheritDoc} */
-  @Override
-  public Instant getSignerExpiration() {
-    return this.signerExpiration;
-  }
+    @Override
+    public Instant getSignerExpiration() {
+        return this.signerExpiration;
+    }
 
   /** {@inheritDoc} */
-  @Override
-  public String getSignerCountry() {
-    return this.country;
-  }
+    @Override
+    public String getSignerCountry() {
+        return this.country;
+    }
 
-  /**
-   * Assigns the algorithm to use.
-   * <p>
-   * {@link SignatureAlgorithm#ES256} is the default for EC keys and {@link SignatureAlgorithm#PS256} is the default for
-   * RSA keys.
-   * </p>
-   * 
+    /**
+     * Assigns the algorithm to use.
+     * <p>
+     * {@link SignatureAlgorithm#ES256} is the default for EC keys and {@link SignatureAlgorithm#PS256} is the default for
+     * RSA keys.
+     * </p>
+     *
    * @param algorithmIdentifier
    *          the algorithm to use
-   */
-  public void setAlgorithmIdentifier(final SignatureAlgorithm algorithmIdentifier) {
-    if (algorithmIdentifier != null) {
-      this.algorithmIdentifier = algorithmIdentifier;
+     */
+    public void setAlgorithmIdentifier(final SignatureAlgorithm algorithmIdentifier) {
+        if (algorithmIdentifier != null) {
+            this.algorithmIdentifier = algorithmIdentifier;
+        }
     }
-  }
 
-  /**
-   * Gets the country from the certificate's subject DN.
-   * 
+    /**
+     * Gets the country from the certificate's subject DN.
+     *
    * @param cert
    *          the certificate
-   * @return the country as a string
+     * @return the country as a string
    * @throws CertificateException
    *           for certificate decoding errors
-   */
-  private static String getCountry(final X509Certificate cert) throws CertificateException {
+     */
+    private static String getCountry(final X509Certificate cert) throws CertificateException {
 
-    try (ByteArrayInputStream bis = new ByteArrayInputStream(cert.getEncoded()); ASN1InputStream as = new ASN1InputStream(bis)) {
-      final ASN1Sequence seq = (ASN1Sequence) as.readObject();
-      final Certificate asn1Cert = Certificate.getInstance(seq);
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(cert.getEncoded()); ASN1InputStream as = new ASN1InputStream(bis)) {
+            final ASN1Sequence seq = (ASN1Sequence) as.readObject();
+            final Certificate asn1Cert = Certificate.getInstance(seq);
 
-      if (asn1Cert.getSubject() == null || asn1Cert.getSubject().getRDNs() == null) {
-        throw new CertificateException("Missing country in certificate subject");
-      }
-      final RDN[] rdns = asn1Cert.getSubject().getRDNs(new ASN1ObjectIdentifier("2.5.4.6"));
-      if (rdns == null || rdns.length == 0) {
-        throw new CertificateException("Missing country in certificate subject");
-      }
-      final ASN1Primitive p = rdns[0].getFirst().getValue().toASN1Primitive();
-      if (p instanceof ASN1String) {
-        return ((ASN1String) p).getString();
-      }
-      throw new CertificateException("Missing country in certificate subject");
+            if (asn1Cert.getSubject() == null || asn1Cert.getSubject().getRDNs() == null) {
+                throw new CertificateException("Missing country in certificate subject");
+            }
+            final RDN[] rdns = asn1Cert.getSubject().getRDNs(new ASN1ObjectIdentifier("2.5.4.6"));
+            if (rdns == null || rdns.length == 0) {
+                throw new CertificateException("Missing country in certificate subject");
+            }
+            final ASN1Primitive p = rdns[0].getFirst().getValue().toASN1Primitive();
+            if (p instanceof ASN1String) {
+                return ((ASN1String) p).getString();
+            }
+            throw new CertificateException("Missing country in certificate subject");
+        } catch (IOException e) {
+            throw new CertificateException("Failed to read certificate", e);
+        }
     }
-    catch (IOException e) {
-      throw new CertificateException("Failed to read certificate", e);
-    }
-  }
 
-  /**
-   * Given a certificate a 8-byte KID is calculated that is the SHA-256 digest over the certificate DER-encoding.
-   * 
+    /**
+     * Given a certificate a 8-byte KID is calculated that is the SHA-256 digest over the certificate DER-encoding.
+     *
    * @param cert
    *          the certificate
-   * @return a 8 byte KID
-   */
-  private static byte[] calculateKid(final X509Certificate cert) {
+     * @return a 8 byte KID
+     */
+    private static byte[] calculateKid(final X509Certificate cert) {
 
-    try {
-      final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
-      final byte[] sha256 = digest.digest(cert.getEncoded());
-      final byte[] kid = new byte[8];
-      System.arraycopy(sha256, 0, kid, 0, 8);
-      return kid;
+            final byte[] sha256 = digest.digest(cert.getEncoded());
+            final byte[] kid = new byte[8];
+            System.arraycopy(sha256, 0, kid, 0, 8);
+            return kid;
+        } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+            throw new SecurityException(e);
+        }
     }
-    catch (NoSuchAlgorithmException | CertificateEncodingException e) {
-      throw new SecurityException(e);
-    }
-  }
 
-  /**
-   * Assigns a specific Java Security Provider that should be used when signing. If not assigned, a default provider
-   * will be used.
-   * 
+    /**
+     * Assigns a specific Java Security Provider that should be used when signing. If not assigned, a default provider
+     * will be used.
+     *
    * @param securityProvider
    *          the security provider
-   */
-  public void setSecurityProvider(final Provider securityProvider) {
-    this.securityProvider = securityProvider;
-  }
+     */
+    public void setSecurityProvider(final Provider securityProvider) {
+        this.securityProvider = securityProvider;
+    }
 
 }

--- a/src/main/java/se/digg/dgc/signatures/impl/PkiCredential.java
+++ b/src/main/java/se/digg/dgc/signatures/impl/PkiCredential.java
@@ -1,0 +1,42 @@
+package se.digg.dgc.signatures.impl;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * A simple class, holding a X509Certificate and it's keys
+ *
+ * @author Johannes Marchart, johannes.marchart@itsv.at
+ */
+public class PkiCredential {
+
+    private PrivateKey privateKey;
+    private PublicKey publicKey;
+    private X509Certificate certificate;
+
+    public PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(PrivateKey privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public PublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(PublicKey publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public X509Certificate getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(X509Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+}

--- a/src/test/java/se/digg/dgc/cose/CoseSign1_ObjectTest.java
+++ b/src/test/java/se/digg/dgc/cose/CoseSign1_ObjectTest.java
@@ -1,27 +1,24 @@
 /*
  * MIT License
- * 
+ *
  * Copyright 2021 Myndigheten för digital förvaltning (DIGG)
  */
 package se.digg.dgc.cose;
+
+import com.upokecenter.cbor.CBORObject;
+import org.junit.Assert;
+import org.junit.Test;
+import se.digg.dgc.helper.PkiCredentialHelper;
+import se.digg.dgc.signatures.cose.CoseSign1_Object;
+import se.digg.dgc.signatures.cose.HeaderParameterKey;
+import se.digg.dgc.signatures.cose.SignatureAlgorithm;
+import se.digg.dgc.signatures.cwt.Cwt;
+import se.digg.dgc.signatures.impl.PkiCredential;
 
 import java.security.MessageDigest;
 import java.security.SignatureException;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.springframework.core.io.ClassPathResource;
-
-import com.upokecenter.cbor.CBORObject;
-
-import se.digg.dgc.signatures.cose.CoseSign1_Object;
-import se.digg.dgc.signatures.cose.HeaderParameterKey;
-import se.digg.dgc.signatures.cose.SignatureAlgorithm;
-import se.digg.dgc.signatures.cwt.Cwt;
-import se.swedenconnect.security.credential.KeyStoreCredential;
-import se.swedenconnect.security.credential.PkiCredential;
 
 /**
  * Test cases for CoseSign1_Object.
@@ -32,90 +29,88 @@ import se.swedenconnect.security.credential.PkiCredential;
  */
 public class CoseSign1_ObjectTest {
 
-  private PkiCredential rsa;
-  private PkiCredential ecdsa;
+    private PkiCredential rsa;
+    private PkiCredential ecdsa;
 
-  private static final char[] password = "secret".toCharArray();
+    private static final String password = "secret";
 
-  public CoseSign1_ObjectTest() throws Exception {
-    this.rsa = new KeyStoreCredential(new ClassPathResource("rsa.jks"), password, "signer", password);
-    this.rsa.init();
-    this.ecdsa = new KeyStoreCredential(new ClassPathResource("ecdsa.jks"), password, "signer", password);
-    this.ecdsa.init();
-  }
+    public CoseSign1_ObjectTest() throws Exception {
+        this.rsa = PkiCredentialHelper.getFromJKS("rsa.jks", password, "se");
+        this.ecdsa = PkiCredentialHelper.getFromJKS("ecdsa.jks", password, "se");
+    }
 
-  @Test
-  public void testSignVerifyEc() throws Exception {
-    final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
-    final CoseSign1_Object sign = CoseSign1_Object.builder()
-      .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
-      .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
-      .content(cwt.encode())
-      .build();
+    @Test
+    public void testSignVerifyEc() throws Exception {
+        final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
+        final CoseSign1_Object sign = CoseSign1_Object.builder()
+                .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
+                .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
+                .content(cwt.encode())
+                .build();
 
-    sign.sign(this.ecdsa.getPrivateKey(), null);
+        sign.sign(this.ecdsa.getPrivateKey(), null);
 
-    final byte[] encoding = sign.encode();
+        final byte[] encoding = sign.encode();
 
-    CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
+        CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
 
-    // In a real life scenario, this is where I would ask for the KID (in order to locate the public key to use).
-    final byte[] kid = object2.getKeyIdentifier();
-    Assert.assertTrue(kid.length == 8);
+        // In a real life scenario, this is where I would ask for the KID (in order to locate the public key to use).
+        final byte[] kid = object2.getKeyIdentifier();
+        Assert.assertTrue(kid.length == 8);
 
-    object2.verifySignature(this.ecdsa.getPublicKey());
+        object2.verifySignature(this.ecdsa.getPublicKey());
 
-    final Cwt cwt2 = object2.getCwt();
-    Assert.assertEquals("SE", cwt2.getIssuer());
-  }
-  
-  @Test
-  public void testSignVerifyRsa() throws Exception {
+        final Cwt cwt2 = object2.getCwt();
+        Assert.assertEquals("SE", cwt2.getIssuer());
+    }
 
-    final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
-    final CoseSign1_Object sign = CoseSign1_Object.builder()
-      .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.PS256.getCborObject())
-      .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.rsa.getCertificate())))
-      .content(cwt.encode())
-      .build();
+    @Test
+    public void testSignVerifyRsa() throws Exception {
 
-    sign.sign(this.rsa.getPrivateKey(), null);
+        final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
+        final CoseSign1_Object sign = CoseSign1_Object.builder()
+                .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.PS256.getCborObject())
+                .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.rsa.getCertificate())))
+                .content(cwt.encode())
+                .build();
 
-    final byte[] encoding = sign.encode();
+        sign.sign(this.rsa.getPrivateKey(), null);
 
-    CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
-    object2.verifySignature(this.rsa.getPublicKey());
+        final byte[] encoding = sign.encode();
 
-    final Cwt cwt2 = object2.getCwt();
-    Assert.assertEquals("SE", cwt2.getIssuer());
-  }
-  
-  @Test(expected = SignatureException.class)
-  public void testFailedVerify() throws Exception {
-    final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
-    final CoseSign1_Object sign = CoseSign1_Object.builder()
-      .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
-      .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
-      .content(cwt.encode())
-      .build();
+        CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
+        object2.verifySignature(this.rsa.getPublicKey());
 
-    sign.sign(this.ecdsa.getPrivateKey(), null);
+        final Cwt cwt2 = object2.getCwt();
+        Assert.assertEquals("SE", cwt2.getIssuer());
+    }
 
-    final byte[] encoding = sign.encode();
-    
-    // Change the signature
-    encoding[encoding.length - 1] = 0x00;
+    @Test(expected = SignatureException.class)
+    public void testFailedVerify() throws Exception {
+        final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
+        final CoseSign1_Object sign = CoseSign1_Object.builder()
+                .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
+                .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
+                .content(cwt.encode())
+                .build();
 
-    CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
-    object2.verifySignature(this.ecdsa.getPublicKey());
-  }
+        sign.sign(this.ecdsa.getPrivateKey(), null);
 
-  private static byte[] getKeyId(final X509Certificate cert) throws Exception {
-    final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-    final byte[] sha256 = digest.digest(cert.getEncoded());
-    final byte[] kid = new byte[8];
-    System.arraycopy(sha256, 0, kid, 0, 8);
-    return kid;
-  }
+        final byte[] encoding = sign.encode();
+
+        // Change the signature
+        encoding[encoding.length - 1] = 0x00;
+
+        CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
+        object2.verifySignature(this.ecdsa.getPublicKey());
+    }
+
+    private static byte[] getKeyId(final X509Certificate cert) throws Exception {
+        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        final byte[] sha256 = digest.digest(cert.getEncoded());
+        final byte[] kid = new byte[8];
+        System.arraycopy(sha256, 0, kid, 0, 8);
+        return kid;
+    }
 
 }

--- a/src/test/java/se/digg/dgc/cose/CoseSign1_ObjectTest.java
+++ b/src/test/java/se/digg/dgc/cose/CoseSign1_ObjectTest.java
@@ -29,88 +29,88 @@ import java.time.Instant;
  */
 public class CoseSign1_ObjectTest {
 
-    private PkiCredential rsa;
-    private PkiCredential ecdsa;
+  private PkiCredential rsa;
+  private PkiCredential ecdsa;
 
-    private static final String password = "secret";
+  private static final String password = "secret";
 
-    public CoseSign1_ObjectTest() throws Exception {
-        this.rsa = PkiCredentialHelper.getFromJKS("rsa.jks", password, "se");
-        this.ecdsa = PkiCredentialHelper.getFromJKS("ecdsa.jks", password, "se");
-    }
+  public CoseSign1_ObjectTest() throws Exception {
+    this.rsa = PkiCredentialHelper.getFromJKS("rsa.jks", password, "se");
+    this.ecdsa = PkiCredentialHelper.getFromJKS("ecdsa.jks", password, "se");
+  }
 
-    @Test
-    public void testSignVerifyEc() throws Exception {
-        final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
-        final CoseSign1_Object sign = CoseSign1_Object.builder()
-                .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
-                .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
-                .content(cwt.encode())
-                .build();
+  @Test
+  public void testSignVerifyEc() throws Exception {
+    final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
+    final CoseSign1_Object sign = CoseSign1_Object.builder()
+      .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
+      .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
+      .content(cwt.encode())
+      .build();
 
-        sign.sign(this.ecdsa.getPrivateKey(), null);
+    sign.sign(this.ecdsa.getPrivateKey(), null);
 
-        final byte[] encoding = sign.encode();
+    final byte[] encoding = sign.encode();
 
-        CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
+    CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
 
-        // In a real life scenario, this is where I would ask for the KID (in order to locate the public key to use).
-        final byte[] kid = object2.getKeyIdentifier();
-        Assert.assertTrue(kid.length == 8);
+    // In a real life scenario, this is where I would ask for the KID (in order to locate the public key to use).
+    final byte[] kid = object2.getKeyIdentifier();
+    Assert.assertTrue(kid.length == 8);
 
-        object2.verifySignature(this.ecdsa.getPublicKey());
+    object2.verifySignature(this.ecdsa.getPublicKey());
 
-        final Cwt cwt2 = object2.getCwt();
-        Assert.assertEquals("SE", cwt2.getIssuer());
-    }
+    final Cwt cwt2 = object2.getCwt();
+    Assert.assertEquals("SE", cwt2.getIssuer());
+  }
 
-    @Test
-    public void testSignVerifyRsa() throws Exception {
+  @Test
+  public void testSignVerifyRsa() throws Exception {
 
-        final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
-        final CoseSign1_Object sign = CoseSign1_Object.builder()
-                .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.PS256.getCborObject())
-                .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.rsa.getCertificate())))
-                .content(cwt.encode())
-                .build();
+    final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
+    final CoseSign1_Object sign = CoseSign1_Object.builder()
+      .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.PS256.getCborObject())
+      .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.rsa.getCertificate())))
+      .content(cwt.encode())
+      .build();
 
-        sign.sign(this.rsa.getPrivateKey(), null);
+    sign.sign(this.rsa.getPrivateKey(), null);
 
-        final byte[] encoding = sign.encode();
+    final byte[] encoding = sign.encode();
 
-        CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
-        object2.verifySignature(this.rsa.getPublicKey());
+    CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
+    object2.verifySignature(this.rsa.getPublicKey());
 
-        final Cwt cwt2 = object2.getCwt();
-        Assert.assertEquals("SE", cwt2.getIssuer());
-    }
+    final Cwt cwt2 = object2.getCwt();
+    Assert.assertEquals("SE", cwt2.getIssuer());
+  }
 
-    @Test(expected = SignatureException.class)
-    public void testFailedVerify() throws Exception {
-        final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
-        final CoseSign1_Object sign = CoseSign1_Object.builder()
-                .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
-                .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
-                .content(cwt.encode())
-                .build();
+  @Test(expected = SignatureException.class)
+  public void testFailedVerify() throws Exception {
+    final Cwt cwt = Cwt.builder().issuer("SE").issuedAt(Instant.now()).build();
+    final CoseSign1_Object sign = CoseSign1_Object.builder()
+      .protectedAttribute(HeaderParameterKey.ALG.getCborObject(), SignatureAlgorithm.ES256.getCborObject())
+      .protectedAttribute(HeaderParameterKey.KID.getCborObject(), CBORObject.FromObject(getKeyId(this.ecdsa.getCertificate())))
+      .content(cwt.encode())
+      .build();
 
-        sign.sign(this.ecdsa.getPrivateKey(), null);
+    sign.sign(this.ecdsa.getPrivateKey(), null);
 
-        final byte[] encoding = sign.encode();
+    final byte[] encoding = sign.encode();
 
-        // Change the signature
-        encoding[encoding.length - 1] = 0x00;
+    // Change the signature
+    encoding[encoding.length - 1] = 0x00;
 
-        CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
-        object2.verifySignature(this.ecdsa.getPublicKey());
-    }
+    CoseSign1_Object object2 = CoseSign1_Object.decode(encoding);
+    object2.verifySignature(this.ecdsa.getPublicKey());
+  }
 
-    private static byte[] getKeyId(final X509Certificate cert) throws Exception {
-        final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        final byte[] sha256 = digest.digest(cert.getEncoded());
-        final byte[] kid = new byte[8];
-        System.arraycopy(sha256, 0, kid, 0, 8);
-        return kid;
-    }
+  private static byte[] getKeyId(final X509Certificate cert) throws Exception {
+    final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    final byte[] sha256 = digest.digest(cert.getEncoded());
+    final byte[] kid = new byte[8];
+    System.arraycopy(sha256, 0, kid, 0, 8);
+    return kid;
+  }
 
 }

--- a/src/test/java/se/digg/dgc/service/impl/DefaultDGCBarcodeEncoderDecoderTest.java
+++ b/src/test/java/se/digg/dgc/service/impl/DefaultDGCBarcodeEncoderDecoderTest.java
@@ -33,58 +33,58 @@ import java.util.UUID;
  */
 public class DefaultDGCBarcodeEncoderDecoderTest {
 
-    private PkiCredential ecdsa;
+  private PkiCredential ecdsa;
 
-    private static String password = "secret";
+  private static String password = "secret";
 
-    public DefaultDGCBarcodeEncoderDecoderTest() throws Exception {
-        this.ecdsa = PkiCredentialHelper.getFromJKS("ecdsa.jks", password, "se");
-    }
+  public DefaultDGCBarcodeEncoderDecoderTest() throws Exception {
+    this.ecdsa = PkiCredentialHelper.getFromJKS("ecdsa.jks", password, "se");
+  }
 
-    @Test
-    public void testEncodeDecodeBarcode() throws Exception {
+  @Test
+  public void testEncodeDecodeBarcode() throws Exception {
 
-        final Instant expire = Instant.now().plus(Duration.ofDays(30));
-        final DigitalGreenCertificate dgc = getTestDGC();
+    final Instant expire = Instant.now().plus(Duration.ofDays(30));
+    final DigitalGreenCertificate dgc = getTestDGC();
 
-        final DefaultDGCBarcodeEncoder encoder = new DefaultDGCBarcodeEncoder(new DefaultDGCSigner(this.ecdsa), new DefaultBarcodeCreator());
-        encoder.setTransliterateNames(true);
+    final DefaultDGCBarcodeEncoder encoder = new DefaultDGCBarcodeEncoder(new DefaultDGCSigner(this.ecdsa), new DefaultBarcodeCreator());
+    encoder.setTransliterateNames(true);
 
-        final Barcode barcode = encoder.encodeToBarcode(dgc, expire);
+    final Barcode barcode = encoder.encodeToBarcode(dgc, expire);
 
-        final DefaultDGCBarcodeDecoder decoder = new DefaultDGCBarcodeDecoder(
-                new DefaultDGCSignatureVerifier(), (x, y) -> Arrays.asList(this.ecdsa.getCertificate()), new DefaultBarcodeDecoder());
+    final DefaultDGCBarcodeDecoder decoder = new DefaultDGCBarcodeDecoder(
+      new DefaultDGCSignatureVerifier(), (x, y) -> Arrays.asList(this.ecdsa.getCertificate()), new DefaultBarcodeDecoder());
 
-        final DigitalGreenCertificate dgc2 = decoder.decodeBarcode(barcode.getImage());
-        Assert.assertEquals(dgc, dgc2);
-        Assert.assertEquals("KARL<MAARTEN", dgc2.getNam().getGnt());
-        Assert.assertEquals("LINDSTROEM", dgc2.getNam().getFnt());
-    }
+    final DigitalGreenCertificate dgc2 = decoder.decodeBarcode(barcode.getImage());
+    Assert.assertEquals(dgc, dgc2);
+    Assert.assertEquals("KARL<MAARTEN", dgc2.getNam().getGnt());
+    Assert.assertEquals("LINDSTROEM", dgc2.getNam().getFnt());
+  }
 
-    private DigitalGreenCertificate getTestDGC() {
-        DigitalGreenCertificate dgc = new DigitalGreenCertificate();
-        dgc.setVer("1.0.0");
+  private DigitalGreenCertificate getTestDGC() {
+    DigitalGreenCertificate dgc = new DigitalGreenCertificate();
+    dgc.setVer("1.0.0");
 
-        dgc.setNam(new PersonName().withGn("Karl Mårten").withFn("Lindström"));
-        dgc.setDob(LocalDate.parse("1969-11-29"));
+    dgc.setNam(new PersonName().withGn("Karl Mårten").withFn("Lindström"));
+    dgc.setDob(LocalDate.parse("1969-11-29"));
 
 
-        VaccinationEntry vac = new VaccinationEntry();
-        vac
-                .withCi(UUID.randomUUID().toString())
-                .withTg("840539006")
-                .withDt(LocalDate.parse("2021-04-02"))
-                .withCo("SE")
-                .withDn(Integer.valueOf(1))
-                .withSd(Integer.valueOf(2))
-                .withIs("eHälsomyndigheten")
-                .withMa("ORG-100001699")
-                .withMp("CVnCoV")
-                .withVp("1119349007");
+    VaccinationEntry vac = new VaccinationEntry();
+    vac
+      .withCi(UUID.randomUUID().toString())
+      .withTg("840539006")
+      .withDt(LocalDate.parse("2021-04-02"))
+      .withCo("SE")
+      .withDn(Integer.valueOf(1))
+      .withSd(Integer.valueOf(2))
+      .withIs("eHälsomyndigheten")
+      .withMa("ORG-100001699")
+      .withMp("CVnCoV")
+      .withVp("1119349007");
 
-        dgc.setV(Arrays.asList(vac));
+    dgc.setV(Arrays.asList(vac));
 
-        return dgc;
-    }
+    return dgc;
+  }
 
 }

--- a/src/test/java/se/digg/dgc/service/impl/DefaultDGCBarcodeEncoderDecoderTest.java
+++ b/src/test/java/se/digg/dgc/service/impl/DefaultDGCBarcodeEncoderDecoderTest.java
@@ -5,89 +5,86 @@
  */
 package se.digg.dgc.service.impl;
 
+import org.junit.Assert;
+import org.junit.Test;
+import se.digg.dgc.encoding.Barcode;
+import se.digg.dgc.encoding.impl.DefaultBarcodeCreator;
+import se.digg.dgc.encoding.impl.DefaultBarcodeDecoder;
+import se.digg.dgc.helper.PkiCredentialHelper;
+import se.digg.dgc.payload.v1.DigitalGreenCertificate;
+import se.digg.dgc.payload.v1.PersonName;
+import se.digg.dgc.payload.v1.VaccinationEntry;
+import se.digg.dgc.signatures.impl.DefaultDGCSignatureVerifier;
+import se.digg.dgc.signatures.impl.DefaultDGCSigner;
+import se.digg.dgc.signatures.impl.PkiCredential;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.springframework.core.io.ClassPathResource;
-
-import se.digg.dgc.encoding.Barcode;
-import se.digg.dgc.encoding.impl.DefaultBarcodeCreator;
-import se.digg.dgc.encoding.impl.DefaultBarcodeDecoder;
-import se.digg.dgc.payload.v1.DigitalGreenCertificate;
-import se.digg.dgc.payload.v1.PersonName;
-import se.digg.dgc.payload.v1.VaccinationEntry;
-import se.digg.dgc.signatures.impl.DefaultDGCSignatureVerifier;
-import se.digg.dgc.signatures.impl.DefaultDGCSigner;
-import se.swedenconnect.security.credential.KeyStoreCredential;
-import se.swedenconnect.security.credential.PkiCredential;
-
 /**
  * Test cases for {@link DefaultDGCBarcodeEncoder}.
- * 
+ *
  * @author Martin Lindström (martin@idsec.se)
  * @author Henrik Bengtsson (extern.henrik.bengtsson@digg.se)
  * @author Henric Norlander (extern.henric.norlander@digg.se)
  */
 public class DefaultDGCBarcodeEncoderDecoderTest {
-  
-  private PkiCredential ecdsa;
 
-  private static final char[] password = "secret".toCharArray();
+    private PkiCredential ecdsa;
 
-  public DefaultDGCBarcodeEncoderDecoderTest() throws Exception {
-    this.ecdsa = new KeyStoreCredential(new ClassPathResource("ecdsa.jks"), password, "signer", password);
-    this.ecdsa.init();
-  }
-  
-  @Test
-  public void testEncodeDecodeBarcode() throws Exception {
-    
-    final Instant expire = Instant.now().plus(Duration.ofDays(30));
-    final DigitalGreenCertificate dgc = getTestDGC();
-    
-    final DefaultDGCBarcodeEncoder encoder = new DefaultDGCBarcodeEncoder(new DefaultDGCSigner(this.ecdsa), new DefaultBarcodeCreator());
-    encoder.setTransliterateNames(true);
-    
-    final Barcode barcode = encoder.encodeToBarcode(dgc, expire);
-    
-    final DefaultDGCBarcodeDecoder decoder = new DefaultDGCBarcodeDecoder(
-      new DefaultDGCSignatureVerifier(), (x,y) -> Arrays.asList(this.ecdsa.getCertificate()), new DefaultBarcodeDecoder());
-    
-    final DigitalGreenCertificate dgc2 = decoder.decodeBarcode(barcode.getImage());
-    Assert.assertEquals(dgc, dgc2);
-    Assert.assertEquals("KARL<MAARTEN", dgc2.getNam().getGnt());
-    Assert.assertEquals("LINDSTROEM", dgc2.getNam().getFnt());
-  }
-  
-  private DigitalGreenCertificate getTestDGC() {
-    DigitalGreenCertificate dgc = new DigitalGreenCertificate();
-    dgc.setVer("1.0.0");
-    
-    dgc.setNam(new PersonName().withGn("Karl Mårten").withFn("Lindström"));
-    dgc.setDob(LocalDate.parse("1969-11-29"));
-    
-    
-    VaccinationEntry vac = new VaccinationEntry();    
-    vac
-      .withCi(UUID.randomUUID().toString())
-      .withTg("840539006")
-      .withDt(LocalDate.parse("2021-04-02"))
-      .withCo("SE")
-      .withDn(Integer.valueOf(1))
-      .withSd(Integer.valueOf(2))
-      .withIs("eHälsomyndigheten")
-      .withMa("ORG-100001699")
-      .withMp("CVnCoV")
-      .withVp("1119349007");
-      
-    dgc.setV(Arrays.asList(vac));
-    
-    return dgc;
-  }
+    private static String password = "secret";
+
+    public DefaultDGCBarcodeEncoderDecoderTest() throws Exception {
+        this.ecdsa = PkiCredentialHelper.getFromJKS("ecdsa.jks", password, "se");
+    }
+
+    @Test
+    public void testEncodeDecodeBarcode() throws Exception {
+
+        final Instant expire = Instant.now().plus(Duration.ofDays(30));
+        final DigitalGreenCertificate dgc = getTestDGC();
+
+        final DefaultDGCBarcodeEncoder encoder = new DefaultDGCBarcodeEncoder(new DefaultDGCSigner(this.ecdsa), new DefaultBarcodeCreator());
+        encoder.setTransliterateNames(true);
+
+        final Barcode barcode = encoder.encodeToBarcode(dgc, expire);
+
+        final DefaultDGCBarcodeDecoder decoder = new DefaultDGCBarcodeDecoder(
+                new DefaultDGCSignatureVerifier(), (x, y) -> Arrays.asList(this.ecdsa.getCertificate()), new DefaultBarcodeDecoder());
+
+        final DigitalGreenCertificate dgc2 = decoder.decodeBarcode(barcode.getImage());
+        Assert.assertEquals(dgc, dgc2);
+        Assert.assertEquals("KARL<MAARTEN", dgc2.getNam().getGnt());
+        Assert.assertEquals("LINDSTROEM", dgc2.getNam().getFnt());
+    }
+
+    private DigitalGreenCertificate getTestDGC() {
+        DigitalGreenCertificate dgc = new DigitalGreenCertificate();
+        dgc.setVer("1.0.0");
+
+        dgc.setNam(new PersonName().withGn("Karl Mårten").withFn("Lindström"));
+        dgc.setDob(LocalDate.parse("1969-11-29"));
+
+
+        VaccinationEntry vac = new VaccinationEntry();
+        vac
+                .withCi(UUID.randomUUID().toString())
+                .withTg("840539006")
+                .withDt(LocalDate.parse("2021-04-02"))
+                .withCo("SE")
+                .withDn(Integer.valueOf(1))
+                .withSd(Integer.valueOf(2))
+                .withIs("eHälsomyndigheten")
+                .withMa("ORG-100001699")
+                .withMp("CVnCoV")
+                .withVp("1119349007");
+
+        dgc.setV(Arrays.asList(vac));
+
+        return dgc;
+    }
 
 }

--- a/src/test/java/se/digg/dgc/service/interop/InteropConsumeTest.java
+++ b/src/test/java/se/digg/dgc/service/interop/InteropConsumeTest.java
@@ -30,39 +30,39 @@ import static se.digg.dgc.helper.PkiCredentialHelper.getResourceInputStream;
  */
 public class InteropConsumeTest {
 
-    @Test
-    public void testDecodeFromBarcode() throws Exception {
-        final byte[] image = getResourceInputStream("interop/hcert-testdata/test1.png").readAllBytes();
-        final X509Certificate cert = getFromPEM("interop/hcert-testdata/issuer1.crt");
+  @Test
+  public void testDecodeFromBarcode() throws Exception {
+    final byte[] image = getResourceInputStream("interop/hcert-testdata/test1.png").readAllBytes();
+    final X509Certificate cert = getFromPEM("interop/hcert-testdata/issuer1.crt");
 
-        // Decode barcode into the Base45 string ...
-        final DefaultBarcodeDecoder decoder = new DefaultBarcodeDecoder();
-        final String base45 = decoder.decodeToString(image, StandardCharsets.US_ASCII);
+    // Decode barcode into the Base45 string ...
+    final DefaultBarcodeDecoder decoder = new DefaultBarcodeDecoder();
+    final String base45 = decoder.decodeToString(image, StandardCharsets.US_ASCII);
 
-        // Assert the the prefix is there.
-        Assert.assertTrue(base45.startsWith("HC1"));
+    // Assert the the prefix is there.
+    Assert.assertTrue(base45.startsWith("HC1"));
 
-        // Base45 decode
-        final byte[] compressedCwt = Base45.getDecoder().decode(base45.substring(3));
+    // Base45 decode
+    final byte[] compressedCwt = Base45.getDecoder().decode(base45.substring(3));
 
-        // Decompress
-        final byte[] cwt = Zlib.decompress(compressedCwt, true);
+    // Decompress
+    final byte[] cwt = Zlib.decompress(compressedCwt, true);
 
-        // Verify signature
-        final DefaultDGCSignatureVerifier verifier = new DefaultDGCSignatureVerifier();
-        DGCSignatureVerifier.Result result = verifier.verify(cwt, (c, k) -> Arrays.asList(cert));
+    // Verify signature
+    final DefaultDGCSignatureVerifier verifier = new DefaultDGCSignatureVerifier();
+    DGCSignatureVerifier.Result result = verifier.verify(cwt, (c, k) -> Arrays.asList(cert));
 
-        System.out.println(String.format("CWT: issuing-country='%s', issued-at='%s', expires='%s',signer-cert='%s'",
-                result.getCountry(), result.getIssuedAt(), result.getExpires(), result.getSignerCertificate().getSubjectX500Principal()));
+    System.out.println(String.format("CWT: issuing-country='%s', issued-at='%s', expires='%s',signer-cert='%s'",
+      result.getCountry(), result.getIssuedAt(), result.getExpires(), result.getSignerCertificate().getSubjectX500Principal()));
 
-        // Dump HCERT contents in JSON
-        final CBORObject dgcObject = CBORObject.DecodeFromBytes(result.getDgcPayload());
-        System.out.println(dgcObject.ToJSONString());
+    // Dump HCERT contents in JSON
+    final CBORObject dgcObject = CBORObject.DecodeFromBytes(result.getDgcPayload());
+    System.out.println(dgcObject.ToJSONString());
 
-        // Deserialize into our Java representation ...
+    // Deserialize into our Java representation ...
 //    final ObjectMapper cborMapper = new CBORMapper();
 //    final DigitalGreenCertificate dgc = cborMapper.readValue(result.getHcert(), DigitalGreenCertificate.class);
-    }
+  }
 
 
 }

--- a/src/test/java/se/digg/dgc/service/interop/InteropConsumeTest.java
+++ b/src/test/java/se/digg/dgc/service/interop/InteropConsumeTest.java
@@ -5,77 +5,64 @@
  */
 package se.digg.dgc.service.interop;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.cert.X509Certificate;
-import java.util.Arrays;
-
-import org.apache.commons.io.FileUtils;
+import com.upokecenter.cbor.CBORObject;
 import org.junit.Assert;
 import org.junit.Test;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-
-import com.upokecenter.cbor.CBORObject;
-
 import se.digg.dgc.encoding.Base45;
 import se.digg.dgc.encoding.Zlib;
 import se.digg.dgc.encoding.impl.DefaultBarcodeDecoder;
 import se.digg.dgc.signatures.DGCSignatureVerifier;
 import se.digg.dgc.signatures.impl.DefaultDGCSignatureVerifier;
-import se.swedenconnect.security.credential.factory.X509CertificateFactoryBean;
+
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+import static se.digg.dgc.helper.PkiCredentialHelper.getFromPEM;
+import static se.digg.dgc.helper.PkiCredentialHelper.getResourceInputStream;
 
 /**
  * Interoperability tests with other implementations
- * 
+ *
  * @author Martin Lindström (martin@idsec.se)
  * @author Henrik Bengtsson (extern.henrik.bengtsson@digg.se)
  * @author Henric Norlander (extern.henric.norlander@digg.se)
  */
 public class InteropConsumeTest {
-  
-  @Test
-  public void testDecodeFromBarcode() throws Exception {
-    final byte[] image = getFile(new ClassPathResource("interop/hcert-testdata/test1.png"));
-    final X509Certificate cert = getCertificate(new ClassPathResource("interop/hcert-testdata/issuer1.crt"));
 
-    // Decode barcode into the Base45 string ...
-    final DefaultBarcodeDecoder decoder = new DefaultBarcodeDecoder();
-    final String base45 = decoder.decodeToString(image, StandardCharsets.US_ASCII);
-    
-    // Assert the the prefix is there.
-    Assert.assertTrue(base45.startsWith("HC1"));
-    
-    // Base45 decode
-    final byte[] compressedCwt = Base45.getDecoder().decode(base45.substring(3));
-    
-    // Decompress
-    final byte[] cwt = Zlib.decompress(compressedCwt, true);
-    
-    // Verify signature
-    final DefaultDGCSignatureVerifier verifier = new DefaultDGCSignatureVerifier();
-    DGCSignatureVerifier.Result result = verifier.verify(cwt, (c,k) -> Arrays.asList(cert));
-    
-    System.out.println(String.format("CWT: issuing-country='%s', issued-at='%s', expires='%s',signer-cert='%s'", 
-      result.getCountry(), result.getIssuedAt(), result.getExpires(), result.getSignerCertificate().getSubjectX500Principal()));
+    @Test
+    public void testDecodeFromBarcode() throws Exception {
+        final byte[] image = getResourceInputStream("interop/hcert-testdata/test1.png").readAllBytes();
+        final X509Certificate cert = getFromPEM("interop/hcert-testdata/issuer1.crt");
 
-    // Dump HCERT contents in JSON
-    final CBORObject dgcObject = CBORObject.DecodeFromBytes(result.getDgcPayload()); 
-    System.out.println(dgcObject.ToJSONString());
-    
-    // Deserialize into our Java representation ...
+        // Decode barcode into the Base45 string ...
+        final DefaultBarcodeDecoder decoder = new DefaultBarcodeDecoder();
+        final String base45 = decoder.decodeToString(image, StandardCharsets.US_ASCII);
+
+        // Assert the the prefix is there.
+        Assert.assertTrue(base45.startsWith("HC1"));
+
+        // Base45 decode
+        final byte[] compressedCwt = Base45.getDecoder().decode(base45.substring(3));
+
+        // Decompress
+        final byte[] cwt = Zlib.decompress(compressedCwt, true);
+
+        // Verify signature
+        final DefaultDGCSignatureVerifier verifier = new DefaultDGCSignatureVerifier();
+        DGCSignatureVerifier.Result result = verifier.verify(cwt, (c, k) -> Arrays.asList(cert));
+
+        System.out.println(String.format("CWT: issuing-country='%s', issued-at='%s', expires='%s',signer-cert='%s'",
+                result.getCountry(), result.getIssuedAt(), result.getExpires(), result.getSignerCertificate().getSubjectX500Principal()));
+
+        // Dump HCERT contents in JSON
+        final CBORObject dgcObject = CBORObject.DecodeFromBytes(result.getDgcPayload());
+        System.out.println(dgcObject.ToJSONString());
+
+        // Deserialize into our Java representation ...
 //    final ObjectMapper cborMapper = new CBORMapper();
 //    final DigitalGreenCertificate dgc = cborMapper.readValue(result.getHcert(), DigitalGreenCertificate.class);
-  }
-  
-  private static byte[] getFile(final Resource resource) throws IOException {
-    return FileUtils.readFileToByteArray(resource.getFile());
-  }
-  
-  private static X509Certificate getCertificate(final Resource resource) throws Exception {
-    final X509CertificateFactoryBean factory = new X509CertificateFactoryBean(resource);
-    factory.afterPropertiesSet();
-    return factory.getObject();
-  }
+    }
+
 
 }


### PR DESCRIPTION
Hello,

I'm working on the DGC project in vienna, perhaps it's useful for others, that the dependencies for credentials-support, which pulls spring5 are removed from the project