### PR TITLE
Include Base45 payload in Barcode class to be able to use it later

### DIFF
--- a/create-validate/pom.xml
+++ b/create-validate/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>se.digg.dgc</groupId>
     <artifactId>dgc-parent</artifactId>
-    <version>0.9.3</version>
+    <version>0.9.4-SNAPSHOT</version>
   </parent>  
 
   <artifactId>dgc-create-validate</artifactId>

--- a/create-validate/src/main/java/se/digg/dgc/encoding/Barcode.java
+++ b/create-validate/src/main/java/se/digg/dgc/encoding/Barcode.java
@@ -32,7 +32,7 @@ public class Barcode {
   /** The height of the barcode in pixels. */
   private final int height;
 
-  /** The payload of the barcode. */
+  /** The content of the barcode, i.e., the data "in" the barcode. */
   private final String payload;
 
   /**
@@ -48,8 +48,11 @@ public class Barcode {
    *          the width in pixels
    * @param height
    *          the height in pixels
+   * @param payload
+   *          the barcode payload (content)
    */
-  public Barcode(final BarcodeType type, final byte[] image, final ImageFormat imageFormat, final int width, final int height, final String payload) {
+  public Barcode(final BarcodeType type, final byte[] image, final ImageFormat imageFormat, 
+      final int width, final int height, final String payload) {
     this.type = Optional.ofNullable(type).orElseThrow(() -> new IllegalArgumentException("type must not be null"));
     this.image = Optional.ofNullable(image)
       .filter(c -> c.length > 0)
@@ -57,7 +60,7 @@ public class Barcode {
     this.imageFormat = Optional.ofNullable(imageFormat).orElseThrow(() -> new IllegalArgumentException("imageFormat must not be null"));
     this.width = width;
     this.height = height;
-    this.payload = payload;
+    this.payload = Optional.ofNullable(payload).orElseThrow(() -> new IllegalArgumentException("payload must not be null"));
 
     if (this.width <= 0) {
       throw new IllegalArgumentException("width must be a positive integer");
@@ -113,7 +116,7 @@ public class Barcode {
   }
 
   /**
-   * Gets the payload of the barcode.
+   * Gets the payload/contents of the barcode.
    * 
    * @return the payload
    */

--- a/create-validate/src/main/java/se/digg/dgc/encoding/Barcode.java
+++ b/create-validate/src/main/java/se/digg/dgc/encoding/Barcode.java
@@ -32,6 +32,9 @@ public class Barcode {
   /** The height of the barcode in pixels. */
   private final int height;
 
+  /** The payload of the barcode. */
+  private final String payload;
+
   /**
    * Constructor.
    * 
@@ -46,7 +49,7 @@ public class Barcode {
    * @param height
    *          the height in pixels
    */
-  public Barcode(final BarcodeType type, final byte[] image, final ImageFormat imageFormat, final int width, final int height) {
+  public Barcode(final BarcodeType type, final byte[] image, final ImageFormat imageFormat, final int width, final int height, final String payload) {
     this.type = Optional.ofNullable(type).orElseThrow(() -> new IllegalArgumentException("type must not be null"));
     this.image = Optional.ofNullable(image)
       .filter(c -> c.length > 0)
@@ -54,6 +57,7 @@ public class Barcode {
     this.imageFormat = Optional.ofNullable(imageFormat).orElseThrow(() -> new IllegalArgumentException("imageFormat must not be null"));
     this.width = width;
     this.height = height;
+    this.payload = payload;
 
     if (this.width <= 0) {
       throw new IllegalArgumentException("width must be a positive integer");
@@ -106,6 +110,15 @@ public class Barcode {
    */
   public int getHeight() {
     return this.height;
+  }
+
+  /**
+   * Gets the payload of the barcode.
+   * 
+   * @return the payload
+   */
+  public String getPayload() {
+    return this.payload;
   }
 
   /**

--- a/create-validate/src/main/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreator.java
+++ b/create-validate/src/main/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreator.java
@@ -86,7 +86,7 @@ public class DefaultBarcodeCreator implements BarcodeCreator {
       try (final ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
         MatrixToImageWriter.writeToStream(bitMatrix, imageFormat.getName(), stream);
         byte[] bytes = stream.toByteArray();
-        return new Barcode(this.type, bytes, this.imageFormat, this.widthAndHeight, this.widthAndHeight);
+        return new Barcode(this.type, bytes, this.imageFormat, this.widthAndHeight, this.widthAndHeight, contents);
       }
       catch (final IOException e) {
         throw new BarcodeException("Failed to create barcode - " + e.getMessage(), e);

--- a/create-validate/src/test/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreatorTest.java
+++ b/create-validate/src/test/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreatorTest.java
@@ -11,8 +11,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import se.digg.dgc.encoding.Barcode;
-import se.digg.dgc.encoding.impl.DefaultBarcodeCreator;
-import se.digg.dgc.encoding.impl.DefaultBarcodeDecoder;
 
 /**
  * Test cases for DefaultBarcodeCreator.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.digg.dgc</groupId>
   <artifactId>dgc-parent</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>DIGG :: Digital Green Certificate :: DGC Java</name>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>se.digg.dgc</groupId>
     <artifactId>dgc-parent</artifactId>
-    <version>0.9.3</version>
+    <version>0.9.4-SNAPSHOT</version>
   </parent>  
 
   <artifactId>dgc-schema</artifactId>


### PR DESCRIPTION
The Base45 payload is saved in the Barcode class so that it can be used later for example when you create wallet passes