### PR TITLE
Fixes concerning date-time formats

### DIFF
--- a/create-validate/src/test/java/se/digg/dgc/interop/DGCTestDataVerifier.java
+++ b/create-validate/src/test/java/se/digg/dgc/interop/DGCTestDataVerifier.java
@@ -22,10 +22,6 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.upokecenter.cbor.CBORDateConverter;
 import com.upokecenter.cbor.CBORObject;
 
@@ -35,6 +31,7 @@ import se.digg.dgc.encoding.Base45;
 import se.digg.dgc.encoding.DGCConstants;
 import se.digg.dgc.encoding.Zlib;
 import se.digg.dgc.encoding.impl.DefaultBarcodeDecoder;
+import se.digg.dgc.payload.v1.DigitalGreenCertificate;
 import se.digg.dgc.signatures.CertificateProvider;
 import se.digg.dgc.signatures.DGCSignatureVerifier;
 import se.digg.dgc.signatures.cose.CoseSign1_Object;
@@ -53,16 +50,6 @@ public class DGCTestDataVerifier {
 
   /** Logger */
   private static final Logger log = LoggerFactory.getLogger(DGCTestDataVerifier.class);
-
-  /** JSON Mapper. */
-  private static ObjectMapper jsonMapper = new ObjectMapper();
-
-  static {
-    jsonMapper.registerModule(new JavaTimeModule());
-    jsonMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    jsonMapper.setSerializationInclusion(Include.NON_NULL);
-    jsonMapper.setSerializationInclusion(Include.NON_EMPTY);
-  }
 
   /**
    * Validates the data from the test statement.
@@ -449,7 +436,7 @@ public class DGCTestDataVerifier {
    *           for parsing errors
    */
   public static TestStatement getTestStatement(final String file) throws IOException {
-    return jsonMapper.readValue(new File(file), TestStatement.class);
+    return DigitalGreenCertificate.getJSONMapper().readValue(new File(file), TestStatement.class);
   }
 
   // Hidden

--- a/create-validate/src/test/java/se/digg/dgc/interop/TestStatement.java
+++ b/create-validate/src/test/java/se/digg/dgc/interop/TestStatement.java
@@ -26,9 +26,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import se.digg.dgc.payload.v1.DigitalGreenCertificate;
 
 /**
  * A representation of a test statement, see
@@ -42,16 +41,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestStatement {
-
-  /** The JSON mapper. */
-  private static ObjectMapper jsonMapper = new ObjectMapper();
-
-  static {
-    jsonMapper.registerModule(new JavaTimeModule());
-    jsonMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    jsonMapper.setSerializationInclusion(Include.NON_NULL);
-    jsonMapper.setSerializationInclusion(Include.NON_EMPTY);
-  }
 
   /** The JSON holding the DGC payload. */
   @JsonProperty("JSON")
@@ -99,7 +88,7 @@ public class TestStatement {
    *           for JSON processing errors
    */
   public String toJson() throws JsonProcessingException {
-    return jsonMapper.writeValueAsString(this);
+    return DigitalGreenCertificate.getJSONMapper().writeValueAsString(this);
   }
 
   /**
@@ -121,7 +110,7 @@ public class TestStatement {
   @JsonIgnore
   public String getJsonString() throws JsonProcessingException {
     return this.json != null
-        ? jsonMapper.writeValueAsString(this.json)
+        ? DigitalGreenCertificate.getJSONMapper().writeValueAsString(this.json)
         : null;
   }
 


### PR DESCRIPTION
The library now can parse date-time strings in test entries that use offsets.

Also, made fix in DGC encode to make sure date-times are encoded with tag 0 and as strings.

@sondaica Make sure that the app can handle test entries with tag 0 (string ISO-8601), tag 1 (numeric - seconds since epoch) and no tag (ISO-8601 format). I have also run into a number of date-time strings using offsets.