### PR TITLE
Making sure that CWT times are encoded as ints.

### DIFF
--- a/create-validate/src/main/java/se/digg/dgc/signatures/cwt/support/CBORInstantConverter.java
+++ b/create-validate/src/main/java/se/digg/dgc/signatures/cwt/support/CBORInstantConverter.java
@@ -33,7 +33,7 @@ public class CBORInstantConverter implements ICBORToFromConverter<Instant> {
     if (obj == null) {
       return null;
     }
-    return untaggedDateConverter.ToCBORObject(new Date(obj.toEpochMilli()));
+    return untaggedDateConverter.ToCBORObject(new Date(obj.getEpochSecond() * 1000L));
   }
 
   /** {@inheritDoc} */

--- a/create-validate/src/test/java/se/digg/dgc/cwt/CwtTest.java
+++ b/create-validate/src/test/java/se/digg/dgc/cwt/CwtTest.java
@@ -8,11 +8,11 @@ package se.digg.dgc.cwt;
 import java.time.Duration;
 import java.time.Instant;
 
-import org.apache.commons.codec.binary.Hex;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.upokecenter.cbor.CBORObject;
+import com.upokecenter.cbor.CBORType;
 
 import se.digg.dgc.signatures.cwt.Cwt;
 
@@ -41,7 +41,14 @@ public class CwtTest {
       .claim(99, object)
       .build();
     
-    System.out.println(Hex.encodeHexString(cwt.encode()));
+    //System.out.println(Hex.encodeHexString(cwt.encode()));
+    
+    // Make sure that an int is used to represent the times...
+    CBORObject obj = CBORObject.DecodeFromBytes(cwt.encode());
+    CBORObject iat = obj.get(6);
+    Assert.assertFalse(iat.isTagged());
+    Assert.assertTrue(iat.getType() == CBORType.Integer);
+    Assert.assertEquals(seconds, iat.AsInt64Value());
     
     Cwt cwt2 = Cwt.decode(cwt.encode());
     


### PR DESCRIPTION
To avoid interoperability issues we make sure that we just use ints for `iat` and `exp` in CWT:s.
