### PR TITLE
Size fixes for barcodes

### DIFF
--- a/create-validate/pom.xml
+++ b/create-validate/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>se.digg.dgc</groupId>
     <artifactId>dgc-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
   </parent>  
 
   <artifactId>dgc-create-validate</artifactId>

--- a/create-validate/src/main/java/se/digg/dgc/encoding/Barcode.java
+++ b/create-validate/src/main/java/se/digg/dgc/encoding/Barcode.java
@@ -67,7 +67,6 @@ public class Barcode {
     this.width = width;
     this.height = height;
     this.payload = Optional.ofNullable(payload).orElseThrow(() -> new IllegalArgumentException("payload must not be null"));
-
     if (this.width <= 0) {
       throw new IllegalArgumentException("width must be a positive integer");
     }

--- a/create-validate/src/main/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreator.java
+++ b/create-validate/src/main/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreator.java
@@ -87,8 +87,8 @@ public class DefaultBarcodeCreator implements BarcodeCreator {
       try (final ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
         MatrixToImageWriter.writeToStream(bitMatrix, imageFormat.getName(), stream);
         byte[] bytes = stream.toByteArray();
-        return new Barcode(this.type, bytes, this.imageFormat, this.toSvgImage(bitMatrix), this.widthAndHeight, this.widthAndHeight,
-          contents);
+        return new Barcode(this.type, bytes, this.imageFormat, this.toSvgImage(bitMatrix), 
+          bitMatrix.getWidth(), bitMatrix.getHeight(), contents);
       }
       catch (final IOException e) {
         throw new BarcodeException("Failed to create barcode - " + e.getMessage(), e);
@@ -184,13 +184,16 @@ public class DefaultBarcodeCreator implements BarcodeCreator {
    * <p>
    * {@value #DEFAULT_WIDTH_AND_HEIGHT} is the default.
    * </p>
+   * <p>
+   * If 0 is supplied the smallest possible size will be choosen for the generated code.
+   * </p>
    * 
    * @param widthAndHeight
    *          the width/height
    */
   public void setWidthAndHeight(final int widthAndHeight) {
-    if (widthAndHeight <= 0) {
-      throw new IllegalArgumentException("widthAndHeight must be greater than 0");
+    if (widthAndHeight < 0) {
+      throw new IllegalArgumentException("widthAndHeight must not be less than 0");
     }
     this.widthAndHeight = widthAndHeight;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>se.digg.dgc</groupId>
   <artifactId>dgc-parent</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>DIGG :: EU Digital Covid Certificate :: DCC Java</name>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>se.digg.dgc</groupId>
     <artifactId>dgc-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
   </parent>  
 
   <artifactId>dgc-schema</artifactId>


### PR DESCRIPTION
Prepared so that we can create optomized QR-codes and then "drag" them to the desired size in HTML (will never give QR-codes with white margin).
