### PR TITLE
Generate crisp edges in SVG

### DIFF
--- a/create-validate/src/main/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreator.java
+++ b/create-validate/src/main/java/se/digg/dgc/encoding/impl/DefaultBarcodeCreator.java
@@ -115,7 +115,9 @@ public class DefaultBarcodeCreator implements BarcodeCreator {
       .append(width)
       .append(" ")
       .append(height)
-      .append("\">")
+      .append("\"")
+      .append(" shape-rendering=\"crispEdges\"")
+      .append(">")
       .append(System.lineSeparator());
 
     BitArray row = new BitArray(width);


### PR DESCRIPTION
SVGs are generated with a small white horizontal line between modules. This is mitigated by adding `shape-rendering="crispEdges"`.

See the following examples.

Without `crispEdges`:
![image](https://user-images.githubusercontent.com/45845951/157219525-c4a9182b-1cba-4ef9-8d1d-3ef311255e7e.png)

With `crispEdges`:
![image](https://user-images.githubusercontent.com/45845951/157219557-2865b71e-2124-499a-ad38-1e27e978025b.png)

